### PR TITLE
Issue #16 first implementation for login display

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+
+import { Spacer } from "@/components/common/ui/spacer";
+import { InputArea } from "@/components/pages/entry-pages/input-area";
+import { LinkArea } from "@/components/pages/entry-pages/link-area";
+
+const LoginPage: React.FC = () => {
+  return (
+    <Spacer
+      minHeight="screen"
+      display="flex"
+      className="items-center justify-center bg-white text-black"
+    >
+      <Spacer
+        display="flex flex-col"
+        gap="xsmall"
+        padding="medium"
+        rounded="lg"
+        border={{ color: "brand-200", width: "2" }}
+      >
+        <Spacer>
+          <h3 className="text-center text-lg font-bold">ログイン</h3>
+        </Spacer>
+        <InputArea
+          label="メールアドレス"
+          type="email"
+          placeholder="メールアドレスを入力"
+          onChange={() => {}}
+        />
+        <InputArea
+          label="パスワード"
+          type="password"
+          placeholder="パスワードを入力"
+          onChange={() => {}}
+        />
+        {/* 
+        TODO: 
+        - Set up onClick handler for the login button
+        - Use CustomButton component
+        */}
+        <button
+          className="w-full bg-brand-500 text-white py-2 rounded hover:opacity-90"
+          onClick={() => {}}
+        >
+          ログイン
+        </button>
+        <LinkArea attrs={{ href: "/" }}>パスワードを忘れた方はこちら</LinkArea>
+        <LinkArea attrs={{ href: "/sign-up" }}>新規登録はこちら</LinkArea>
+      </Spacer>
+    </Spacer>
+  );
+};
+
+export default LoginPage;

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+
+import { Spacer } from "@/components/common/ui/spacer";
+import { InputArea } from "@/components/pages/entry-pages/input-area";
+import { LinkArea } from "@/components/pages/entry-pages/link-area";
+
+/**
+ * TODO:
+ * This page is using the same layout and components as LoginPage.
+ * However, we should create a specific design for SignUpPage in the future.
+ */
+const SignUpPage: React.FC = () => {
+  return (
+    <Spacer
+      minHeight="screen"
+      display="flex"
+      backGround="white"
+      className="items-center justify-center text-black"
+    >
+      <Spacer
+        display="flex flex-col"
+        gap="xsmall"
+        padding="medium"
+        rounded="lg"
+        border={{ color: "brand-200", width: "2" }}
+      >
+        <Spacer>
+          <h3 className="text-center text-lg font-bold">新規登録</h3>
+        </Spacer>
+        <InputArea
+          label="ユーザー名"
+          type="text"
+          placeholder="ユーザー名を入力"
+          onChange={() => {}}
+        />
+        <InputArea
+          label="メールアドレス"
+          type="email"
+          placeholder="メールアドレスを入力"
+          onChange={() => {}}
+        />
+        <InputArea
+          label="パスワード"
+          type="password"
+          placeholder="パスワードを入力"
+          onChange={() => {}}
+        />
+        <InputArea
+          label="パスワード（確認用）"
+          type="password"
+          placeholder="もう一度パスワードを入力"
+          onChange={() => {}}
+        />
+        <button
+          className="w-full bg-brand-500 text-white py-2 rounded hover:opacity-90"
+          onClick={() => {}}
+        >
+          アカウントを作成
+        </button>
+        <LinkArea attrs={{ href: "/login" }}>ログインはこちら</LinkArea>
+      </Spacer>
+    </Spacer>
+  );
+};
+
+export default SignUpPage;

--- a/src/components/pages/entry-pages/input-area/index.tsx
+++ b/src/components/pages/entry-pages/input-area/index.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+
+import { Spacer } from "@/components/common/ui/spacer";
+
+type InputAreaProps = {
+  label: string;
+  name?: string;
+  type?: string;
+  value?: string;
+  placeholder?: string;
+  onChange: React.ChangeEventHandler<HTMLInputElement>;
+};
+
+export const InputArea = ({
+  label,
+  name,
+  type,
+  value,
+  placeholder,
+  onChange,
+}: InputAreaProps) => {
+  return (
+    <Spacer>
+      <label className="text-sm">{label}</label>
+      <input
+        type={type}
+        name={name}
+        value={value}
+        placeholder={placeholder}
+        onChange={onChange}
+        className="w-full border border-gray-300 rounded px-2 py-1"
+      />
+    </Spacer>
+  );
+};

--- a/src/components/pages/entry-pages/link-area/index.tsx
+++ b/src/components/pages/entry-pages/link-area/index.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { Spacer } from "@/components/common/ui/spacer";
+
+type LinkAreaProps = {
+  children?: React.ReactNode;
+  attrs: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+};
+
+export const LinkArea: React.FC<LinkAreaProps> = ({ children, attrs }) => {
+  return (
+    <Spacer className="text-center text-sm">
+      <a
+        href={attrs.href}
+        target={attrs.target}
+        className="underline text-zinc-400"
+      >
+        {children}
+      </a>
+    </Spacer>
+  );
+};


### PR DESCRIPTION
## 概要

<!-- この PR の目的を簡潔に説明してください。 -->
- ログイン画面と新規登録画面のUI開発
- ページ横断レイアウトコンポーネント`Spacer`の開発

## 変更内容

<!-- どのような変更を行ったかを箇条書きで書いてください。 -->
- `app/{login, sign-up}/page.tsx`を作成
- `InputArea`と`LinkArea`のコンポーネントを作成
- ページ横断で利用可能なUIコンポーネントとして`src/components/common/ui/spacer/index.tsx`を作成(別PRへ移動)

## 成果物

<!-- 変更後の UI / 動作が確認できるスクリーンショットや GIF を添付してください。 -->
<img width="420" height="904" alt="image" src="https://github.com/user-attachments/assets/df878cce-ca70-44f0-a535-411e9a89e713" />
<img width="421" height="906" alt="image" src="https://github.com/user-attachments/assets/3ba05016-c6fe-44c2-bcb9-77feb6c8c380" />


## 関連 Issue

<!-- 関連する Issue のリンクを貼ってください。 -->

- resolves #16 

## 補足 / コメント

<!-- レビュアーへの補足情報や注意点があれば記載してください。 -->
### Remarks
- レイアウトについてはあまり自信がないので、こっちのほうがいいんじゃないかみたいな意見があったら教えてください
- 新規登録画面については作り直す可能性があります
### Remaining Tasks
- Buttonコンポーネントの作成
- 他画面とのレイアウトの統一