### PR TITLE
Issue #48 ヘッダーの実装

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import Header from "@/components/common/container/header";
 import CreateLeagueCard from "@/components/pages/home/create-league-card/index";
 import LeagueCard from "@/components/pages/home/league-card/index";
 
@@ -10,6 +11,7 @@ export const Home: React.FC = () => {
 
   return (
     <div className="flex-1 bg-white min-h-full font-jp">
+      <Header />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Welcome Header */}
         <div className="mb-8">

--- a/src/components/common/container/header/constants/index.ts
+++ b/src/components/common/container/header/constants/index.ts
@@ -1,0 +1,43 @@
+import { BarChart3, Home, PlusCircle, Trophy, Users } from "lucide-react";
+
+// TODO: 中身は要調整
+export const NAV_ITEMS = [
+  {
+    icon: Home,
+    label: "ダッシュボード",
+    href: "/",
+    active: typeof window !== "undefined" && window.location.pathname === "/",
+  },
+  {
+    icon: Trophy,
+    label: "リーグ",
+    href: "/leagues",
+    active:
+      typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/leagues"),
+  },
+  {
+    icon: PlusCircle,
+    label: "対局記録",
+    href: "/games/new",
+    active:
+      typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/games"),
+  },
+  {
+    icon: BarChart3,
+    label: "成績",
+    href: "/statistics",
+    active:
+      typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/statistics"),
+  },
+  {
+    icon: Users,
+    label: "メンバー",
+    href: "/members",
+    active:
+      typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/members"),
+  },
+];

--- a/src/components/common/container/header/hooks/index.ts
+++ b/src/components/common/container/header/hooks/index.ts
@@ -1,0 +1,17 @@
+import { useState } from "react";
+
+import { mockUser } from "@/mocks/user";
+
+export const useHeader = () => {
+  const userName = mockUser.name;
+
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleClose = () => setIsMenuOpen(false);
+  const handleLogout = () => {
+    // TODO: ログアウト処理を入れる
+    setIsMenuOpen(false);
+  };
+
+  return { userName, isMenuOpen, setIsMenuOpen, handleClose, handleLogout };
+};

--- a/src/components/common/container/header/index.tsx
+++ b/src/components/common/container/header/index.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { LogOut, Menu, Settings, User, X } from "lucide-react";
+
+import Link from "next/link";
+
+import { NAV_ITEMS } from "./constants";
+import { useHeader } from "./hooks/index";
+
+export const Header: React.FC = () => {
+  const { userName, isMenuOpen, setIsMenuOpen, handleClose, handleLogout } =
+    useHeader();
+
+  return (
+    <>
+      <header className="sticky top-0 z-50 bg-white border-b-2 border-[#F4D4D4]">
+        {/* 上部バー */}
+        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+          {/* 左：ロゴ + アプリ名 */}
+          <Link href="/" className="flex items-center gap-2">
+            {/* ロゴ（TODO: 後日いい感じのに変更） */}
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-brand-500 shadow-sm">
+              <div className="grid grid-cols-2 gap-[1px]">
+                <span className="block h-3 w-3 rounded-[2px] bg-white/90" />
+                <span className="block h-3 w-3 rounded-[2px] bg-white/70" />
+                <span className="block h-3 w-3 rounded-[2px] bg-white/70" />
+                <span className="block h-3 w-3 rounded-[2px] bg-white/50" />
+              </div>
+            </div>
+            {/* アプリ名（TODO: フォント等調整） */}
+            <span className="ml-2 text-xl font-bold text-[#E8736B]">
+              jongbo
+            </span>
+          </Link>
+
+          {/* 右：ハンバーガーメニュー */}
+          <button
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            className="lg:hidden p-2 rounded-full hover:bg-[#FFF5F5] transition-colors"
+          >
+            {isMenuOpen ? (
+              <X size={20} className="text-[#E8736B]" />
+            ) : (
+              <Menu size={20} className="text-[#E8736B]" />
+            )}
+          </button>
+        </div>
+      </header>
+
+      <div
+        className={`
+          fixed inset-y-0 right-0 z-50 
+          w-64 bg-white border-l-2 border-[#F4D4D4]
+          flex flex-col h-full
+          transform transition-transform duration-300 ease-in-out
+          ${isMenuOpen ? "translate-x-0" : "translate-x-full"}
+        `}
+      >
+        {/* 上部：閉じる */}
+        <div className="flex items-center justify-end px-4 py-3">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-[#8B6B6B] hover:bg-[#FFFAF8]"
+            aria-label="メニューを閉じる"
+          >
+            <X size={20} className="text-[#E8736B]" />
+          </button>
+        </div>
+
+        {/* ナビゲーション部分 */}
+        <div className="flex-1 overflow-y-auto px-4 pb-4">
+          {/* ログイン中ユーザー */}
+          <div className="mb-4 rounded-lg border border-[#F4D4D4] bg-[#FFFAF8] px-3 py-3 shadow-sm">
+            <div className="flex items-center gap-2">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full bg-[#FFF5F5] text-[#E8736B]">
+                <User size={18} strokeWidth={1.5} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-xs text-[#8B6B6B]">
+                  ログイン中のユーザー
+                </span>
+                <span className="text-sm font-medium text-[#4A3636]">
+                  {userName ? `${userName} さん` : "ゲスト"}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Navigation Items */}
+          <div className="space-y-1">
+            {NAV_ITEMS.map((item, index) => (
+              <Link
+                key={index}
+                href={item.href}
+                onClick={handleClose}
+                className={`flex items-center rounded-lg px-3 py-2 transition-colors duration-150 ${
+                  item.active
+                    ? "bg-[#FFF5F5] text-[#E8736B]"
+                    : "text-[#8B6B6B] hover:bg-[#FFFAF8]"
+                }`}
+              >
+                <item.icon size={18} strokeWidth={1.5} />
+                <span className="ml-3 font-medium">{item.label}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* 設定とログアウト */}
+        <div className="border-t-2 border-[#F4D4D4] p-4">
+          <div className="space-y-1">
+            <Link
+              href="/settings"
+              onClick={handleClose}
+              className="flex items-center rounded-lg px-3 py-2 text-[#8B6B6B] transition-colors duration-150 hover:bg-[#FFFAF8]"
+            >
+              <Settings size={18} strokeWidth={1.5} />
+              <span className="ml-3 font-medium">設定</span>
+            </Link>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="flex w-full items-center rounded-lg px-3 py-2 text-[#8B6B6B] transition-colors duration-150 hover:bg-[#FFFAF8]"
+            >
+              <LogOut size={18} strokeWidth={1.5} />
+              <span className="ml-3 font-medium">ログアウト</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## 概要

<!-- この PR の目的を簡潔に説明してください。 -->
以下の要素を持つヘッダーを実装します
- アプリアイコン
- アプリ名
- ハンバーガーメニュー
  - ログインユーザ情報
  - 各リンク先
  - ログアウト機能

## 変更内容

<!-- どのような変更を行ったかを箇条書きで書いてください。 -->

- `layout.tsx`にヘッダーを挿入
- `header/index.tsx`を実装
  - usernameとonLogoutをpropとして渡す（ここは適当に修正したい）
  - ロゴ・アプリ名をヘッダーに表示（いい感じのものを作りたい）
  - ハンバーガーメニューを表示
    - navItemとしてメニューを表示する要素群を定義（ここも必要なものに修正）
    - ログインユーザ情報を表示
    - 設定・ログアウトを表示（実際の機能は後続で実装）

## 成果物

<!-- 変更後の UI / 動作が確認できるスクリーンショットや GIF を添付してください。 -->
<img width="333" height="718" alt="image" src="https://github.com/user-attachments/assets/9981935a-bc64-45ce-b3f3-4f997f17fe60" />
<img width="331" height="719" alt="image" src="https://github.com/user-attachments/assets/ecfcf3d7-3a65-4f58-aaea-3a66fe151179" />


## 関連 Issue

<!-- 関連する Issue のリンクを貼ってください。 -->

- resolves #48

## 補足 / コメント

<!-- レビュアーへの補足情報や注意点があれば記載してください。 -->
リンク先とかは，UIの実装ができてからいい感じに調整したいです．
一旦，レイアウトとしてヘッダーが欲しかったので作ったけど，細かいところの調整はUI実装後でいいと思ってます．
